### PR TITLE
Fixed logic bug in updateConnectionInfo().

### DIFF
--- a/src/tw/fatminmin/xposed/networkspeedindicator/widget/TrafficView.java
+++ b/src/tw/fatminmin/xposed/networkspeedindicator/widget/TrafficView.java
@@ -254,6 +254,8 @@ public class TrafficView extends TextView {
 			networkState = networkInfo.isConnected();
 			networkType = networkInfo.getTypeName().toUpperCase(Locale.ENGLISH);
 			Log.i(TAG, "networkType = " + networkType);
+		}else{
+		    networkState = false;
 		}
 	}
 


### PR DESCRIPTION
If there is no active network connection at all, networkState should be reset to false (which would hide the speed-indicators in the updateViewVisibility())
