### PR TITLE
Put the least specific exception class last

### DIFF
--- a/src/tw/fatminmin/xposed/networkspeedindicator/Module.java
+++ b/src/tw/fatminmin/xposed/networkspeedindicator/Module.java
@@ -108,9 +108,6 @@ public final class Module implements IXposedHookLoadPackage,
     			}
     		});
         }
-        catch(Exception e){
-            Log.e(TAG, "handleLoadPackage failure ignored: ", e);
-        }
         catch(ClassNotFoundError e) {
         	// Clock class not found, ignore
         	Log.w(TAG, "handleLoadPackage failure ignored: ", e);
@@ -118,6 +115,10 @@ public final class Module implements IXposedHookLoadPackage,
         catch(NoSuchMethodError e) {
         	// setAlpha method not found, ignore
         	Log.w(TAG, "handleLoadPackage failure ignored: ", e);
+        }
+        // Catch everything else
+        catch(Exception e){
+            Log.e(TAG, "handleLoadPackage failure ignored: ", e);
         }
     }
     


### PR DESCRIPTION
This should prevent the module from creating daily logs with non critic error messages due to <tt> catch(Exception e)</tt> catching everything.