### PR TITLE
ignore tun0 for more accurate speed.

### DIFF
--- a/src/tw/fatminmin/xposed/networkspeedindicator/widget/TrafficView.java
+++ b/src/tw/fatminmin/xposed/networkspeedindicator/widget/TrafficView.java
@@ -2,6 +2,7 @@ package tw.fatminmin.xposed.networkspeedindicator.widget;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.io.File;
 import java.text.DecimalFormat;
 import java.util.Set;
 
@@ -318,6 +319,7 @@ public final class TrafficView extends TextView {
 		final boolean tx = (traffic_direction == TRANSMIT);
 		long totalBytes = -9; // not -1 because it conflicts with TrafficStats.UNSUPPORTED
 		BufferedReader br = null;
+		BufferedReader br2 = null;
 		
 		try {
 			br = new BufferedReader(new FileReader("/sys/class/net/lo/statistics/" + (tx ? "tx" : "rx") + "_bytes"));
@@ -327,10 +329,19 @@ public final class TrafficView extends TextView {
 			String line = br.readLine();
 			
 			long loBytes = Long.parseLong(line);
+
+      long tun0Bytes = 0;
+
+      File tun0 = new File("/sys/class/net/tun0");
+      if (tun0.exists()) {
+        br2 = new BufferedReader(new FileReader("/sys/class/net/tun0/statistics/" + (tx ? "tx" : "rx") + "_bytes"));
+        String line2 = br2.readLine();
+        tun0Bytes = Long.parseLong(line2);
+      }
 			
-			Log.d(TAG, traffic_direction, " total: ", totalBytes, ", lo: ", loBytes);
+			Log.d(TAG, traffic_direction, " total: ", totalBytes, ", lo: ", loBytes, "tun0: ", tun0Bytes);
 			
-			totalBytes = totalBytes - loBytes;
+			totalBytes = totalBytes - loBytes - tun0Bytes;
 			
 		} catch (Exception e) {
 			Log.i(TAG, "Loopback exclusion failed: ", e);

--- a/src/tw/fatminmin/xposed/networkspeedindicator/widget/TrafficView.java
+++ b/src/tw/fatminmin/xposed/networkspeedindicator/widget/TrafficView.java
@@ -330,14 +330,14 @@ public final class TrafficView extends TextView {
 			
 			long loBytes = Long.parseLong(line);
 
-      long tun0Bytes = 0;
+			long tun0Bytes = 0;
 
-      File tun0 = new File("/sys/class/net/tun0");
-      if (tun0.exists()) {
-        br2 = new BufferedReader(new FileReader("/sys/class/net/tun0/statistics/" + (tx ? "tx" : "rx") + "_bytes"));
-        String line2 = br2.readLine();
-        tun0Bytes = Long.parseLong(line2);
-      }
+			File tun0 = new File("/sys/class/net/tun0");
+			if (tun0.exists()) {
+				br2 = new BufferedReader(new FileReader("/sys/class/net/tun0/statistics/" + (tx ? "tx" : "rx") + "_bytes"));
+				String line2 = br2.readLine();
+				tun0Bytes = Long.parseLong(line2);
+			}
 			
 			Log.d(TAG, traffic_direction, " total: ", totalBytes, ", lo: ", loBytes, "tun0: ", tun0Bytes);
 			
@@ -350,6 +350,13 @@ public final class TrafficView extends TextView {
 			if (br != null) {
 				try {
 					br.close();
+				} catch (Exception e) {
+					// ignore
+				}
+			}
+			if (br2 != null) {
+				try {
+					br2.close();
 				} catch (Exception e) {
 					// ignore
 				}


### PR DESCRIPTION
tun0 is a virtual network interface add by shadowsocks. ignore  tun0 will make the speed more accurately when the shadowsocks is running.
read more about tun0:  https://github.com/chiehmin/Xposed-NetworkSpeedIndicator/issues/86
